### PR TITLE
message_store role does not own the schema

### DIFF
--- a/database/install-privileges.sh
+++ b/database/install-privileges.sh
@@ -17,6 +17,9 @@ function grant-privileges {
 
   base=$(script_dir)
 
+  echo "» schema privileges"
+  psql $database -q -f $base/privileges/schema.sql
+
   echo "» messages table privileges"
   psql $database -q -f $base/privileges/table.sql
 

--- a/database/privileges/schema.sql
+++ b/database/privileges/schema.sql
@@ -1,0 +1,1 @@
+GRANT USAGE ON SCHEMA message_store TO message_store;

--- a/database/schema/message-store.sql
+++ b/database/schema/message-store.sql
@@ -1,1 +1,1 @@
-CREATE SCHEMA IF NOT EXISTS message_store AUTHORIZATION message_store;
+CREATE SCHEMA IF NOT EXISTS message_store;


### PR DESCRIPTION
The message_store role does not need to own the message_store schema.
Allow it to be owned by the installing user, just like all of the other
objects.

We then grant the role `USAGE` privileges on the schema so that it can
access those objects.

This reduces the ability of the `message_store` role to execute DDL
to modify the schema's objects.

It also should address issues creating the schema in managed environments
like Amazon RDS. Fixes https://github.com/message-db/message-db/issues/1

- [x] Verify the installation scripts succeed in Amazon RDS

UPDATE: I verified these updated scripts succeed in a new RDS instance. The only issue I saw was related to the md5 function. It appears the privilege grant is unnecessary:

```
Granting Privileges
- - -
» schema privileges
» messages table privileges
» sequence privileges
» functions privileges
psql:/Users/josh/code/message-db/database/privileges/functions.sql:11: WARNING:  no privileges were granted for "md5"
» views privileges
```

I verified that I can invoke the `md5` function as the `message_store` user.

After installation, I ran `test.sh` against the RDS instance without issue (after creating a password for the `message_store` role).