### PR TITLE
Run commands using postgres connection explicitly

### DIFF
--- a/database/install.sh
+++ b/database/install.sh
@@ -30,7 +30,7 @@ function create-user {
   base=$(script_dir)
 
   echo "» message_store role"
-  psql -q -f $base/roles/message-store.sql
+  psql postgres -q -f $base/roles/message-store.sql
 }
 
 function create-database {

--- a/database/uninstall.sh
+++ b/database/uninstall.sh
@@ -28,13 +28,13 @@ fi
 
 function delete-user {
   echo "» message_store user"
-  psql -P pager=off -q -c "DROP OWNED BY message_store;"
-  psql -P pager=off -q -c "DROP ROLE IF EXISTS message_store;"
+  psql postgres -P pager=off -q -c "DROP OWNED BY message_store;"
+  psql postgres -P pager=off -q -c "DROP ROLE IF EXISTS message_store;"
 }
 
 function delete-database {
   echo "» $database database"
-  psql -P pager=off -q -c "DROP DATABASE IF EXISTS $database;"
+  psql postgres -P pager=off -q -c "DROP DATABASE IF EXISTS $database;"
 }
 
 echo "Deleting database"


### PR DESCRIPTION
When I'm running the install script, I get following error:

```
./database/install.sh 

Installing Database
Version: 1.1.5
= = =
DATABASE_NAME is not set. Using: message_store.

Creating User
- - -
» message_store role
psql: error: could not connect to server: FATAL:  database "katafrakt" does not exist
```

That's because `psql -q -f $base/roles/message-store.sql` which is run first tries to connect default database, which might not exist. Now, apparently `postgres` database does not need to exists always, but [according to the docs](https://www.postgresql.org/docs/9.1/creating-cluster.html):

> The database server itself does not require the postgres database to exist, but many external utility programs assume it exists.

So I guess this approach is safe to use.