### PR TITLE
Quote custom database names in uninstall script

### DIFF
--- a/database/uninstall.sh
+++ b/database/uninstall.sh
@@ -33,7 +33,7 @@ function delete-user {
 
 function delete-database {
   echo "» $database database"
-  psql postgres -P pager=off -q -c "DROP DATABASE IF EXISTS $database;"
+  psql postgres -P pager=off -q -c "DROP DATABASE IF EXISTS \"$database\";"
 }
 
 echo "Deleting database"


### PR DESCRIPTION
Avoid syntax errors in `DROP DATABASE` statement with database names containing dashes.

Sidenote: There is a script in the evt-message_store-postgres-database gem `evt-pg-delete-db` that works correctly for this case as it wraps the `dropdb` binary from postgres. Which one am I supposed to use?

```
❯ DATABASE_NAME='foo-bar' mdb-delete-db            

Uninstalling Database
Version: 1.2.3
= = =

Deleting database
- - -
» foo-bar database
ERROR:  syntax error at or near "-"
LINE 1: DROP DATABASE IF EXISTS foo-bar;
                                   ^
```

Fixed
```
❯ DATABASE_NAME='foo-bar' mdb-delete-db

Uninstalling Database
Version: 1.2.3
= = =

Deleting database
- - -
» foo-bar database

Deleting database user
- - -
» message_store user

= = =
Done Uninstalling Database
Version: 1.2.3

```