### PR TITLE
Column ordering is further optimized

### DIFF
--- a/database/tables/messages.sql
+++ b/database/tables/messages.sql
@@ -3,10 +3,10 @@ CREATE TABLE IF NOT EXISTS message_store.messages (
   position bigint NOT NULL,
   id UUID NOT NULL DEFAULT gen_random_uuid(),
   time TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc') NOT NULL,
-  stream_name text NOT NULL,
-  type text NOT NULL,
   data jsonb,
-  metadata jsonb
+  metadata jsonb,
+  stream_name text NOT NULL,
+  type text NOT NULL
 );
 
 ALTER TABLE message_store.messages ADD PRIMARY KEY (global_position) NOT DEFERRABLE INITIALLY IMMEDIATE;


### PR DESCRIPTION
In theory, jsonb columns have 4-byte alignment, and should therefore come before
the text columns with 1-byte alignment.