### PR TITLE
Implement get_all_messages function

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,11 +277,67 @@ Note: Where `someStream-123` is a _stream name_, `someStream` is a _category_. R
 
 Example: [https://github.com/message-db/message-db/blob/master/test/get-category-messages/get-category-messages.sh](https://github.com/message-db/message-db/blob/master/test/get-category-messages/get-category-messages.sh)
 
+### Get all messages
+
+Retrieve all messages from the store, optionally specifying the starting position, the number of messages to retrieve, the correlation category for Pub/Sub, consumer group parameters, and an additional condition that will be appended to the SQL command's WHERE clause.
+
+``` sql
+CREATE OR REPLACE FUNCTION get_all_messages(
+  position bigint DEFAULT 0,
+  batch_size bigint DEFAULT 1000,
+  correlation varchar DEFAULT NULL,
+  consumer_group_member varchar DEFAULT NULL,
+  consumer_group_size varchar DEFAULT NULL,
+  condition varchar DEFAULT NULL
+)
+```
+
+#### Arguments
+
+| Name | Description | Type | Default | Example |
+| --- | --- | --- | --- | --- |
+| position (optional) | Global position to start retrieving messages from | bigint | 1 | 11 |
+| batch_size (optional) | Number of messages to retrieve | bigint | 1000 | 111 |
+| correlation (optional) | Category or stream name recorded in message metadata's `correlationStreamName` attribute to filter the batch by | varchar | NULL | someCorrelationCategory |
+| consumer_group_member (optional) | The zero-based member number of an individual consumer that is participating in a consumer group | bigint | NULL | 1 |
+| consumer_group_size (optional) | The size of a group of consumers that are cooperatively processing a single category | bigint | NULL | 2 |
+| condition (optional) | SQL condition to filter the batch by | varchar | NULL | messages.time >= current_time |
+
+#### Usage
+
+``` sql
+SELECT * FROM get_all_messages(1, 1000, correlation => 'someCorrelationCateogry', consumer_group_member => 1, consumer_group_size => 2, condition => 'messages.time >= current_time');
+```
+
+```
+-[ RECORD 1 ]---+---------------------------------------------------------
+id              | 28d8347f-677e-4738-b6b9-954f1b15463b
+stream_name     | someCategory-123
+type            | SomeType
+position        | 0
+global_position | 1
+data            | {"attribute": "some value"}
+metadata        | {"correlationStreamName": "someCorrelationCateogry-123"}
+time            | 2019-11-24 17:51:49.836341
+-[ RECORD 2 ]---+---------------------------------------------------------
+id              | 57894da7-680b-4483-825c-732dcf873e93
+stream_name     | otherCategory-456
+type            | SomeType
+position        | 0
+global_position | 2
+data            | {"attribute": "some value"}
+metadata        | {"correlationStreamName": "someCorrelationCateogry-123"}
+time            | 2019-11-24 17:51:49.879011
+```
+
+Example: [https://github.com/message-db/message-db/blob/master/test/get-all-messages/get-all-messages.sh](https://github.com/message-db/message-db/blob/master/test/get-all-messages/get-all-messages.sh)
+
 ### Full API Reference
 
 - [write_message](http://docs.eventide-project.org/user-guide/message-db/server-functions.html#write-a-message)
 - [get_stream_messages](http://docs.eventide-project.org/user-guide/message-db/server-functions.html#get-messages-from-a-stream)
 - [get_category_messages](http://docs.eventide-project.org/user-guide/message-db/server-functions.html#get-messages-from-a-category)
+- get_all_messages
 - [get_last_message](http://docs.eventide-project.org/user-guide/message-db/server-functions.html#get-last-message-from-a-stream)
 - [stream_version](http://docs.eventide-project.org/user-guide/message-db/server-functions.html#get-stream-version-from-a-stream)
 - [id](http://docs.eventide-project.org/user-guide/message-db/server-functions.html#get-the-id-from-a-stream-name)

--- a/database/functions/get-all-messages.sql
+++ b/database/functions/get-all-messages.sql
@@ -1,0 +1,123 @@
+CREATE OR REPLACE FUNCTION message_store.get_all_messages(
+  "position" bigint DEFAULT 1,
+  batch_size bigint DEFAULT 1000,
+  correlation varchar DEFAULT NULL,
+  consumer_group_member bigint DEFAULT NULL,
+  consumer_group_size bigint DEFAULT NULL,
+  condition varchar DEFAULT NULL
+)
+RETURNS SETOF message_store.message
+AS $$
+DECLARE
+  _command text;
+BEGIN
+  position := COALESCE(position, 1);
+  batch_size := COALESCE(batch_size, 1000);
+
+  _command := '
+    SELECT
+      id::varchar,
+      stream_name::varchar,
+      type::varchar,
+      position::bigint,
+      global_position::bigint,
+      data::varchar,
+      metadata::varchar,
+      time::timestamp
+    FROM
+      messages
+    WHERE
+      global_position >= $1';
+
+  IF get_all_messages.correlation IS NOT NULL THEN
+    IF position('-' IN get_all_messages.correlation) > 0 THEN
+      RAISE EXCEPTION
+        'Correlation must be a category (Correlation: %)',
+        get_all_messages.correlation;
+    END IF;
+
+    _command := _command || ' AND
+      category(metadata->>''correlationStreamName'') = $3';
+  END IF;
+
+  IF (get_all_messages.consumer_group_member IS NOT NULL AND
+      get_all_messages.consumer_group_size IS NULL) OR
+      (get_all_messages.consumer_group_member IS NULL AND
+      get_all_messages.consumer_group_size IS NOT NULL) THEN
+
+    RAISE EXCEPTION
+      'Consumer group member and size must be specified (Consumer Group Member: %, Consumer Group Size: %)',
+      get_all_messages.consumer_group_member,
+      get_all_messages.consumer_group_size;
+  END IF;
+
+  IF get_all_messages.consumer_group_member IS NOT NULL AND
+      get_all_messages.consumer_group_size IS NOT NULL THEN
+
+    IF get_all_messages.consumer_group_size < 1 THEN
+      RAISE EXCEPTION
+        'Consumer group size must not be less than 1 (Consumer Group Member: %, Consumer Group Size: %)',
+        get_all_messages.consumer_group_member,
+        get_all_messages.consumer_group_size;
+    END IF;
+
+    IF get_all_messages.consumer_group_member < 0 THEN
+      RAISE EXCEPTION
+        'Consumer group member must not be less than 0 (Consumer Group Member: %, Consumer Group Size: %)',
+        get_all_messages.consumer_group_member,
+        get_all_messages.consumer_group_size;
+    END IF;
+
+    IF get_all_messages.consumer_group_member >= get_all_messages.consumer_group_size THEN
+      RAISE EXCEPTION
+        'Consumer group member must be less than the group size (Consumer Group Member: %, Consumer Group Size: %)',
+        get_all_messages.consumer_group_member,
+        get_all_messages.consumer_group_size;
+    END IF;
+
+    _command := _command || ' AND
+      MOD(@hash_64(cardinal_id(stream_name)), $5) = $4';
+  END IF;
+
+  IF get_all_messages.condition IS NOT NULL THEN
+    IF current_setting('message_store.sql_condition', true) IS NULL OR
+        current_setting('message_store.sql_condition', true) = 'off' THEN
+      RAISE EXCEPTION
+        'Retrieval with SQL condition is not activated';
+    END IF;
+
+    _command := _command || ' AND
+      (%s)';
+    _command := format(_command, get_all_messages.condition);
+  END IF;
+
+  _command := _command || '
+    ORDER BY
+      global_position ASC';
+
+  IF get_all_messages.batch_size != -1 THEN
+    _command := _command || '
+      LIMIT
+        $2';
+  END IF;
+
+  IF current_setting('message_store.debug_get', true) = 'on' OR current_setting('message_store.debug', true) = 'on' THEN
+    RAISE NOTICE '» get_all_messages';
+    RAISE NOTICE 'position ($1): %', get_all_messages.position;
+    RAISE NOTICE 'batch_size ($2): %', get_all_messages.batch_size;
+    RAISE NOTICE 'correlation ($3): %', get_all_messages.correlation;
+    RAISE NOTICE 'consumer_group_member ($4): %', get_all_messages.consumer_group_member;
+    RAISE NOTICE 'consumer_group_size ($5): %', get_all_messages.consumer_group_size;
+    RAISE NOTICE 'condition: %', get_all_messages.condition;
+    RAISE NOTICE 'Generated Command: %', _command;
+  END IF;
+
+  RETURN QUERY EXECUTE _command USING
+    get_all_messages.position,
+    get_all_messages.batch_size,
+    get_all_messages.correlation,
+    get_all_messages.consumer_group_member,
+    get_all_messages.consumer_group_size::smallint;
+END;
+$$ LANGUAGE plpgsql
+VOLATILE;

--- a/database/install-functions.sh
+++ b/database/install-functions.sh
@@ -61,6 +61,9 @@ function create-functions {
   echo "» get_stream_messages function"
   psql $database -q -f $base/functions/get-stream-messages.sql
 
+  echo "» get_all_messages function"
+  psql $database -q -f $base/functions/get-all-messages.sql
+
   echo "» get_category_messages function"
   psql $database -q -f $base/functions/get-category-messages.sql
 

--- a/database/privileges/functions.sql
+++ b/database/privileges/functions.sql
@@ -3,6 +3,7 @@ GRANT EXECUTE ON FUNCTION gen_random_uuid() TO message_store;
 GRANT EXECUTE ON FUNCTION message_store.acquire_lock(varchar) TO message_store;
 GRANT EXECUTE ON FUNCTION message_store.cardinal_id(varchar) TO message_store;
 GRANT EXECUTE ON FUNCTION message_store.category(varchar) TO message_store;
+GRANT EXECUTE ON FUNCTION message_store.get_all_messages(bigint, bigint, varchar, bigint, bigint, varchar) TO message_store;
 GRANT EXECUTE ON FUNCTION message_store.get_category_messages(varchar, bigint, bigint, varchar, bigint, bigint, varchar) TO message_store;
 GRANT EXECUTE ON FUNCTION message_store.get_last_stream_message(varchar) TO message_store;
 GRANT EXECUTE ON FUNCTION message_store.get_stream_messages(varchar, bigint, bigint, varchar) TO message_store;

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,21 @@ test/get-stream-messages/condition/condition.sh
 test/get-stream-messages/condition/error-deactivated.sh
 test/get-stream-messages/condition/error-not-activated.sh
 
+test/get-all-messages/get-all-messages.sh
+
+test/get-all-messages/condition/error-deactivated.sh
+test/get-all-messages/condition/error-not-activated.sh
+test/get-all-messages/condition/condition-correlated.sh
+
+test/get-all-messages/consumer-group/correlated.sh
+
+test/get-all-messages/consumer-group/error/missing-group-member.sh
+test/get-all-messages/consumer-group/error/missing-group-size.sh
+test/get-all-messages/consumer-group/error/group-member-equal-to-group-size.sh
+test/get-all-messages/consumer-group/error/group-member-greater-than-group-size.sh
+test/get-all-messages/consumer-group/error/group-member-too-small.sh
+test/get-all-messages/consumer-group/error/group-size-too-small.sh
+
 test/get-category-messages/get-category-messages.sh
 test/get-category-messages/error-not-category.sh
 
@@ -71,5 +86,5 @@ test/reports/type-stream-summary.sh
 test/reports/category-type-summary.sh
 test/reports/type-category-summary.sh
 
-echo "Done"
+echo "All tests complete"
 echo

--- a/test/get-all-messages/condition/condition-correlated.sh
+++ b/test/get-all-messages/condition/condition-correlated.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONDITION CORRELATED"
+echo "============================================"
+echo "- Write 2 messages each to 3 different categories some with a correlation category"
+echo "- Retrieve a batch of 3 messages, starting at global position 0, where the position is greater than or equal to 1, and matching the correlation category"
+echo
+
+source test/_controls.sh
+
+correlation=$(category)
+correlation_stream_name=$(stream-name $correlation)
+echo "Correlation:"
+echo $correlation
+echo
+
+for i in {1..3}; do
+  stream_name=$(stream-name $(category))
+
+  echo "Stream Name: $stream_name"
+
+  write-message-correlated $stream_name 1
+  write-message-correlated $stream_name 1 $correlation_stream_name
+done
+echo
+
+cmd="SELECT * FROM get_all_messages(0, 3, correlation => '$correlation', condition => 'position >= 1');"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+PGOPTIONS='-c message_store.sql_condition=on' psql message_store -U message_store -P pager=off -x -c "$cmd"
+
+echo "= = ="
+echo

--- a/test/get-all-messages/condition/error-deactivated.sh
+++ b/test/get-all-messages/condition/error-deactivated.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "ERROR - GET ALL MESSAGES - CONDITION - FEATURE DEACTIVATED"
+echo "==============================================================="
+echo "- Retrieve a batch of messages from the category using the SQL condition when the SQL condition feature is deactivated"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(condition => 'position >= 1');"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+PGOPTIONS='-c message_store.sql_condition=off' psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/condition/error-not-activated.sh
+++ b/test/get-all-messages/condition/error-not-activated.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "ERROR - GET ALL MESSAGES - CONDITION - FEATURE NOT ACTIVATED"
+echo "================================================================="
+echo "- Retrieve a batch of messages from the category using the SQL condition when the SQL condition feature is deactivated"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(condition => 'position >= 1');"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/correlated.sh
+++ b/test/get-all-messages/consumer-group/correlated.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - CORRELATED"
+echo "==================================================="
+echo "- Write 2 messages each to 10 different categories"
+echo "- Half of the messages have a different cardinal ID that the other half"
+echo "- Retrieve messages from the category that match the consumer group conditions"
+echo
+
+source test/_controls.sh
+
+correlation=$(category)
+correlation_stream_name=$(stream-name $correlation)
+echo "Correlation:"
+echo $correlation
+echo
+
+
+cardinal_id_1=$(id)
+echo "Cardinal ID 1:"
+echo $cardinal_id_1
+echo
+
+for i in {1..5}; do
+  stream_name=$(compound-id-stream-name $(category) $cardinal_id_1)
+
+  echo "Stream Name: $stream_name"
+
+  write-message-correlated $stream_name 1
+  write-message-correlated $stream_name 1 $correlation_stream_name
+done
+echo
+
+
+cardinal_id_2=$(id)
+echo "Cardinal ID 2:"
+echo $cardinal_id_2
+echo
+
+for i in {1..5}; do
+  stream_name=$(compound-id-stream-name $(category) $cardinal_id_2)
+
+  echo "Stream Name: $stream_name"
+
+  write-message-correlated $stream_name 1
+  write-message-correlated $stream_name 1 $correlation_stream_name
+done
+echo
+
+
+echo "Correlated messages for consumer member 0"
+echo
+
+cmd="SELECT * FROM get_all_messages(0, 10, correlation => '$correlation', consumer_group_member => 0, consumer_group_size => 2);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+
+
+echo "A batch of 1 message for consumer member 0 greater than global position 2"
+echo
+
+cmd="SELECT * FROM get_all_messages(2, 1, correlation => '$correlation', consumer_group_member => 0, consumer_group_size => 2);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/error/group-member-equal-to-group-size.sh
+++ b/test/get-all-messages/consumer-group/error/group-member-equal-to-group-size.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - ERROR - GROUP MEMBER EQUAL TO GROUP SIZE"
+echo "================================================================================="
+echo "- Retrieve a batch of messages with a consumer group member equal to the group size"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(consumer_group_member => 1, consumer_group_size => 1);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/error/group-member-greater-than-group-size.sh
+++ b/test/get-all-messages/consumer-group/error/group-member-greater-than-group-size.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - ERROR - GROUP MEMBER GREATER THAN GROUP SIZE"
+echo "====================================================================================="
+echo "- Retrieve a batch of messages with a consumer group member equals the group size"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(consumer_group_member => 2, consumer_group_size => 1);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/error/group-member-too-small.sh
+++ b/test/get-all-messages/consumer-group/error/group-member-too-small.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - ERROR - GROUP MEMBER TOO SMALL"
+echo "======================================================================="
+echo "- Retrieve a batch of messages with a consumer group member that is too small"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages('someCategory', consumer_group_member => -1, consumer_group_size => 1);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/error/group-size-too-small.sh
+++ b/test/get-all-messages/consumer-group/error/group-size-too-small.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - ERROR - GROUP SIZE TOO SMALL"
+echo "====================================================================="
+echo "- Retrieve a batch of messages with a consumer group size that is too small"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(consumer_group_member => 0, consumer_group_size => 0);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/error/missing-group-member.sh
+++ b/test/get-all-messages/consumer-group/error/missing-group-member.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - ERROR - MISSING GROUP MEMBER"
+echo "====================================================================="
+echo "- Retrieve a batch of messages, omitting the consumer group member argument"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(consumer_group_member => 1);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/consumer-group/error/missing-group-size.sh
+++ b/test/get-all-messages/consumer-group/error/missing-group-size.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET ALL MESSAGES - CONSUMER GROUP - ERROR - MISSING GROUP SIZE"
+echo "==================================================================="
+echo "- Retrieve a batch of messages, omitting the consumer group size argument"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+cmd="SELECT * FROM get_all_messages(consumer_group_size => 1);"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/correlated/correlated.sh
+++ b/test/get-all-messages/correlated/correlated.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET CATEGORY MESSAGES - CORRELATED"
+echo "=================================="
+echo "- Write 2 messages each to 3 entity streams in the same category"
+echo "- Retrieve a batch of 2 messages from the category, starting at global position 0 and matching the correlation category"
+echo
+
+source test/_controls.sh
+
+category=$(category)
+echo "Category:"
+echo $category
+echo
+
+correlation=$(category)
+correlation_stream_name=$(stream-name $correlation)
+echo "Correlation:"
+echo $correlation
+echo
+
+for i in {1..3}; do
+  stream_name=$(stream-name $category)
+
+  echo "Stream Name: $stream_name"
+
+  write-message-correlated $stream_name 1
+  write-message-correlated $stream_name 1 $correlation_stream_name
+done
+echo
+
+cmd="SELECT * FROM get_category_messages('$category', 0, 2, correlation => '$correlation');"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+
+echo "= = ="
+echo

--- a/test/get-all-messages/correlated/error-stream-name.sh
+++ b/test/get-all-messages/correlated/error-stream-name.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET CATEGORY MESSAGES - CORRELATED STREAM NAME ERROR"
+echo "===================================================="
+echo "- Retrieve a messages using a stream name as the correlation value"
+echo "- Terminates with an error"
+echo
+
+source test/_controls.sh
+
+category=$(category)
+echo "Category:"
+echo $category
+echo
+
+stream_name=$(stream-name)
+
+echo "Stream Name:"
+echo $stream_name
+echo
+
+cmd="SELECT * FROM get_category_messages('$category', correlation => '$stream_name');"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+set +e
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+set -e
+
+echo "= = ="
+echo

--- a/test/get-all-messages/get-all-messages.sh
+++ b/test/get-all-messages/get-all-messages.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET CATEGORY MESSAGES"
+echo "====================="
+echo "- Write 2 messages each to 3 entity streams in the same category"
+echo "- Retrieve a batch of messages (this batch will likely contain many more messages than were written by this test)"
+echo
+
+source test/_controls.sh
+
+for i in {1..3}; do
+  stream_name=$(stream-name $(category))
+  echo $stream_name
+  write-message $stream_name 2
+done
+echo
+
+cmd="SELECT * FROM get_all_messages();"
+
+echo "Command:"
+echo "$cmd"
+echo
+
+psql message_store -U message_store -P pager=off -x -c "$cmd"
+
+echo "= = ="
+echo


### PR DESCRIPTION
Basically just a copy of `get_category_messages` but with all category filtering removed. It didn't make sense for all tests to be copied, as, without filtering, they end up returning messages from other tests.

Likely there are things missing from this PR so let me know what else would need doing :)

Closes: #27 