### PR TITLE
Use fully qualified names for functions and tables

### DIFF
--- a/database/functions/acquire-lock.sql
+++ b/database/functions/acquire-lock.sql
@@ -7,8 +7,8 @@ DECLARE
   _category varchar;
   _category_name_hash bigint;
 BEGIN
-  _category := category(acquire_lock.stream_name);
-  _category_name_hash := hash_64(_category);
+  _category := message_store.category(acquire_lock.stream_name);
+  _category_name_hash := message_store.hash_64(_category);
   PERFORM pg_advisory_xact_lock(_category_name_hash);
 
   IF current_setting('message_store.debug_write', true) = 'on' OR current_setting('message_store.debug', true) = 'on' THEN

--- a/database/functions/cardinal-id.sql
+++ b/database/functions/cardinal-id.sql
@@ -6,7 +6,7 @@ AS $$
 DECLARE
   _id varchar;
 BEGIN
-  _id := id(cardinal_id.stream_name);
+  _id := message_store.id(cardinal_id.stream_name);
 
   IF _id IS NULL THEN
     RETURN NULL;

--- a/database/functions/get-category-messages.sql
+++ b/database/functions/get-category-messages.sql
@@ -12,7 +12,7 @@ AS $$
 DECLARE
   _command text;
 BEGIN
-  IF NOT is_category(get_category_messages.category) THEN
+  IF NOT message_store.is_category(get_category_messages.category) THEN
     RAISE EXCEPTION
       'Must be a category: %',
       get_category_messages.category;
@@ -32,9 +32,9 @@ BEGIN
       metadata::varchar,
       time::timestamp
     FROM
-      messages
+      message_store.messages
     WHERE
-      category(stream_name) = $1 AND
+      message_store.category(stream_name) = $1 AND
       global_position >= $2';
 
   IF get_category_messages.correlation IS NOT NULL THEN
@@ -45,7 +45,7 @@ BEGIN
     END IF;
 
     _command := _command || ' AND
-      category(metadata->>''correlationStreamName'') = $4';
+      message_store.category(metadata->>''correlationStreamName'') = $4';
   END IF;
 
   IF (get_category_messages.consumer_group_member IS NOT NULL AND

--- a/database/functions/get-last-stream-message.sql
+++ b/database/functions/get-last-stream-message.sql
@@ -18,7 +18,7 @@ BEGIN
       metadata::varchar,
       time::timestamp
     FROM
-      messages
+      message_store.messages
     WHERE
       stream_name = $1';
 

--- a/database/functions/get-stream-messages.sql
+++ b/database/functions/get-stream-messages.sql
@@ -10,7 +10,7 @@ DECLARE
   _command text;
   _setting text;
 BEGIN
-  IF is_category(get_stream_messages.stream_name) THEN
+  IF message_store.is_category(get_stream_messages.stream_name) THEN
     RAISE EXCEPTION
       'Must be a stream name: %',
       get_stream_messages.stream_name;
@@ -30,7 +30,7 @@ BEGIN
       metadata::varchar,
       time::timestamp
     FROM
-      messages
+      message_store.messages
     WHERE
       stream_name = $1 AND
       position >= $2';

--- a/database/functions/stream-version.sql
+++ b/database/functions/stream-version.sql
@@ -9,7 +9,7 @@ BEGIN
   SELECT
     max(position) into _stream_version
   FROM
-    messages
+    message_store.messages
   WHERE
     messages.stream_name = stream_version.stream_name;
 

--- a/database/functions/write-message.sql
+++ b/database/functions/write-message.sql
@@ -13,9 +13,9 @@ DECLARE
   _stream_version bigint;
   _next_position bigint;
 BEGIN
-  PERFORM acquire_lock(write_message.stream_name);
+  PERFORM message_store.acquire_lock(write_message.stream_name);
 
-  _stream_version := stream_version(write_message.stream_name);
+  _stream_version := message_store.stream_version(write_message.stream_name);
 
   IF _stream_version IS NULL THEN
     _stream_version := -1;
@@ -35,7 +35,7 @@ BEGIN
 
   _message_id = uuid(write_message.id);
 
-  INSERT INTO messages
+  INSERT INTO message_store.messages
     (
       id,
       stream_name,


### PR DESCRIPTION
Context: when you grant `message_store` to another role, that role does not automatically have it's `search_path` altered to include `message_store`

In order for message-db to work in those scenarios we need to use qualified function names

Edit: clarified the grammar of the context
