### PR TITLE
scoping the `message_store` schema with security definer

### DIFF
--- a/database/functions/acquire-lock.sql
+++ b/database/functions/acquire-lock.sql
@@ -21,4 +21,6 @@ BEGIN
   RETURN _category_name_hash;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;

--- a/database/functions/cardinal-id.sql
+++ b/database/functions/cardinal-id.sql
@@ -15,4 +15,6 @@ BEGIN
   RETURN SPLIT_PART(_id, '+', 1);
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 IMMUTABLE;

--- a/database/functions/category.sql
+++ b/database/functions/category.sql
@@ -7,4 +7,6 @@ BEGIN
   RETURN SPLIT_PART(category.stream_name, '-', 1);
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 IMMUTABLE;

--- a/database/functions/get-category-messages.sql
+++ b/database/functions/get-category-messages.sql
@@ -130,4 +130,6 @@ BEGIN
     get_category_messages.consumer_group_size::smallint;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;

--- a/database/functions/get-last-stream-message.sql
+++ b/database/functions/get-last-stream-message.sql
@@ -45,4 +45,6 @@ BEGIN
     get_last_stream_message.type;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;

--- a/database/functions/get-stream-messages.sql
+++ b/database/functions/get-stream-messages.sql
@@ -72,4 +72,6 @@ BEGIN
     get_stream_messages.batch_size;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;

--- a/database/functions/hash-64.sql
+++ b/database/functions/hash-64.sql
@@ -10,4 +10,6 @@ BEGIN
   return _hash;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 IMMUTABLE;

--- a/database/functions/id.sql
+++ b/database/functions/id.sql
@@ -15,4 +15,6 @@ BEGIN
   RETURN SUBSTRING(id.stream_name, _id_separator_position + 1);
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 IMMUTABLE;

--- a/database/functions/is-category.sql
+++ b/database/functions/is-category.sql
@@ -11,4 +11,6 @@ BEGIN
   RETURN TRUE;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 IMMUTABLE;

--- a/database/functions/message-store-version.sql
+++ b/database/functions/message-store-version.sql
@@ -5,4 +5,6 @@ BEGIN
   RETURN '1.3.0';
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;

--- a/database/functions/stream-version.sql
+++ b/database/functions/stream-version.sql
@@ -16,4 +16,6 @@ BEGIN
   RETURN _stream_version;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;

--- a/database/functions/write-message.sql
+++ b/database/functions/write-message.sql
@@ -70,4 +70,6 @@ BEGIN
   RETURN _next_position;
 END;
 $$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path=message_store,public,pg_temp
 VOLATILE;


### PR DESCRIPTION
This was my attempt to fix the problem of scoping to the `message_store` and not to pollute the schema in every query. I am not PG expert so not sure if this path is the correct one. In general, the question is whether we need to scope it at all. But in case this sounds like a good solution to the problem #43 / #49 then feel free to accept it. I will also probably try to remove the schema prefix and rather limit it with the privileges for particular user.